### PR TITLE
Refactor Order.java: use Address class for shipping/billing, switch p…

### DIFF
--- a/src/Order.java
+++ b/src/Order.java
@@ -1,3 +1,4 @@
+import java.math.BigDecimal;
 import java.util.ArrayList;
 
 public class Order {
@@ -5,42 +6,22 @@ public class Order {
     private String dateShipped;
     private String userName;
     private String orderStatus;
-    private String shippingAddressLine1;
-    private String shippingAddressLine2;
-    private String shippingAddressCity;
-    private String shippingAddressState;
-    private String shippingAddressZip;
-    private String shippingAddressCountry;
-    private String billingAddressLine1;
-    private String billingAddressLine2;
-    private String billingAddressCity;
-    private String billingAddressState;
-    private String billingAddressZip;
-    private String billingAddressCountry;
+    private Address shippingAddress;
+    private Address billingAddress;
     private ArrayList<CartItem> items;
-    private double orderPrice;
+    private BigDecimal orderPrice;
 
     public Order(Cart cart, User user) {
         this.items = cart.getItems();
         this.orderPrice = calculatePrice(user);
     }
 
-    public void setShippingAddress(String line1, String line2, String city, String state, String zip, String country) {
-        this.shippingAddressLine1 = line1;
-        this.shippingAddressLine2 = line2;
-        this.shippingAddressCity = city;
-        this.shippingAddressState = state;
-        this.shippingAddressZip = zip;
-        this.shippingAddressCountry = country;
+    public void setShippingAddress(Address address) {
+        this.shippingAddress = address;
     }
 
-    public void setBillingAddress(String line1, String line2, String city, String state, String zip, String country) {
-        this.billingAddressLine1 = line1;
-        this.billingAddressLine2 = line2;
-        this.billingAddressCity = city;
-        this.billingAddressState = state;
-        this.billingAddressZip = zip;
-        this.billingAddressCountry = country;
+    public void setBillingAddress(Address address) {
+        this.billingAddress = address;
     }
 
     public void setOrderStatus(String status) {
@@ -65,19 +46,19 @@ public class Order {
         System.out.println("Date Shipped: " + dateShipped);
         System.out.println("User Name: " + userName);
         System.out.println("Order Status: " + orderStatus);
-        System.out.println("Shipping Address: " + shippingAddressLine1 + ", " + shippingAddressLine2 + ", " + shippingAddressCity + ", " + shippingAddressState + ", " + shippingAddressZip + ", " + shippingAddressCountry);
-        System.out.println("Billing Address: " + billingAddressLine1 + ", " + billingAddressLine2 + ", " + billingAddressCity + ", " + billingAddressState + ", " + billingAddressZip + ", " + billingAddressCountry);
+        System.out.println("Shipping Address: " + (shippingAddress != null ? shippingAddress : "N/A"));
+        System.out.println("Billing Address: " + (billingAddress != null ? billingAddress : "N/A"));
         System.out.println("Order Price: $" + orderPrice);
     }
 
-    public double calculatePrice(User user) {
-        double totalPrice = 0.0;
+    private BigDecimal calculatePrice(User user) {
+        BigDecimal totalPrice = BigDecimal.ZERO;
 
         for (CartItem item : items) {
-            totalPrice += item.getTotalPrice();
+            totalPrice = totalPrice.add(BigDecimal.valueOf(item.getTotalPrice()));
         }
-            totalPrice *= user.getDiscountRate(); 
-        
-        return totalPrice;
+
+        BigDecimal discountRate = BigDecimal.valueOf(user.getDiscountRate());
+        return totalPrice.multiply(discountRate);
     }
 }


### PR DESCRIPTION
## Description  
This PR refactors the `Order.java` class to simplify address handling and improve price consistency.  

## Issues  
This PR closes issue #11.  

## Changes Made  
- Replaced multiple string fields for shipping and billing addresses with an `Address` class to remove duplication and data clumps.  
- Updated `Order.java` to use `Address` objects for cleaner and more maintainable code.  
- Switched order price calculations to use `BigDecimal` instead of primitive doubles/floats for improved accuracy and consistency.  
- Updated `printOrderDetails()` to leverage the `Address.toString()` method for cleaner output.  

## Why This Change?  
These changes address **primitive obsession**, **duplicate code**, and **Single Responsibility Principle** violations in `Order.java`.  
