### PR TITLE
remove invalid BigDecimal.valueOf usage

### DIFF
--- a/src/Order.java
+++ b/src/Order.java
@@ -55,7 +55,7 @@ public class Order {
         BigDecimal totalPrice = BigDecimal.ZERO;
 
         for (CartItem item : items) {
-            totalPrice = totalPrice.add(BigDecimal.valueOf(item.getTotalPrice()));
+            totalPrice = totalPrice.add(item.getTotalPrice());
         }
 
         BigDecimal discountRate = BigDecimal.valueOf(user.getDiscountRate());


### PR DESCRIPTION
## Description  
This PR fixes an issue in the `Order.java` class where `BigDecimal.valueOf()` was incorrectly used with a `BigDecimal` parameter. The fix ensures the correct use of `item.getTotalPrice()` directly.  

## Issues  
This PR closes issue #35.  

## Changes Made  
- Updated `Order.java` to remove invalid `BigDecimal.valueOf(item.getTotalPrice())`.  
- Replaced it with:  
  ```java
  totalPrice = totalPrice.add(item.getTotalPrice());
