### PR TITLE
Add setSubscription(String) method to User.java

### DIFF
--- a/src/User.java
+++ b/src/User.java
@@ -32,6 +32,10 @@ public class User {
         return this.subscription;
     }
 
+    public void setSubscription(String subscription) {
+        this.subscription = subscription;
+    }    
+
     public void setShippingAddress(Address address) {
         this.shippingAddress = address;
     }


### PR DESCRIPTION
## Description  
This PR adds the missing `setSubscription(String)` method to the `User` class.  
Without this method, `BookStore.java` cannot assign a subscription role to a user, leading to a compilation error.  

## Issues  
Fixes #41  

## Changes Made  
- Added `setSubscription(String)` method to `User.java`.  

## Why This Change?  
The `User` class defined a `subscription` field but did not provide a setter method.  
This caused `BookStore.java` to fail when calling `user.setSubscription(role)`.  
Adding this method resolves the compilation error and ensures subscription roles can be properly assigned to users.  
