### PR TITLE
Add `Address` class `toString()` method

### DIFF
--- a/src/Address.java
+++ b/src/Address.java
@@ -14,4 +14,9 @@ public class Address {
         this.zip = zip;
         this.country = country;
     }
+
+    @Override
+    public String toString() {
+        return line1 + ", " + line2 + ", " + city + ", " + state + ", " + zip + ", " + country;
+    }
 }


### PR DESCRIPTION
## Description
This PR implements a `toString()` method for the `Address` class.

## Issues
This PR closes issue #31.

## Changes Made
 - Implemented `toString()` method for the `Address` class.

## Why This Change?
Address objects such as the user's `billingAddress` and `shippingAddress` are printed when viewing orders, and hence they require a `toString()` method that properly prints each component of the address separated by commas.