### PR TITLE
Add support for different book types

### DIFF
--- a/src/AudioBook.java
+++ b/src/AudioBook.java
@@ -1,0 +1,8 @@
+import java.math.BigDecimal;
+
+public class AudioBook extends Book {
+    public AudioBook(String title, String author, int yearPublished, BigDecimal price) {
+        super(title, author, yearPublished, price);
+        this.bookType = "audio";
+    }
+}

--- a/src/Book.java
+++ b/src/Book.java
@@ -1,18 +1,17 @@
 import java.math.BigDecimal;
 
-public class Book {
+public abstract class Book {
     private String title;
     private String author;
     private int yearPublished;
     private BigDecimal price;
-    private boolean isPaperback;
+    protected String bookType;
 
-    public Book(String title, String author, int yearPublished, BigDecimal price, boolean isPaperback) {
+    public Book(String title, String author, int yearPublished, BigDecimal price) {
         setTitle(title);
         setAuthor(author);
         setYearPublished(yearPublished);
         setPrice(price);
-        setIsPaperback(isPaperback);
     }
 
     public String getTitle() {
@@ -59,12 +58,8 @@ public class Book {
         this.price = price;
     }
 
-    public boolean getIsPaperback() {
-        return isPaperback;
-    }
-
-    public void setIsPaperback(boolean isPaperback) {
-        this.isPaperback = isPaperback;
+    public String getBookType() {
+        return this.bookType;
     }
 
     public void printBookDetails() {
@@ -72,7 +67,7 @@ public class Book {
         System.out.println("Author: " + author);
         System.out.println("Year Published: " + yearPublished);
         System.out.println("Price: $" + price);
-        System.out.println("Paperback: " + isPaperback);
+        System.out.println("Book Type: " + bookType);
     }
 
     private boolean isPriceValid(BigDecimal price) {

--- a/src/BookazonApp.java
+++ b/src/BookazonApp.java
@@ -1,38 +1,42 @@
 import java.math.BigDecimal;
 
 public class BookazonApp {
-    public static void main(String[] args) {
+        public static void main(String[] args) {
 
-        BookStore bookStore = new BookStore();
+                BookStore bookStore = new BookStore();
 
-        // create books
-        bookStore.addBook(new Book("The Great Gatsby", "F. Scott Fitzgerald", 1925, new BigDecimal("9.99"), true));
-        bookStore.addBook(new Book("To Kill a Mockingbird", "Harper Lee", 1960, new BigDecimal("7.99"), false));
-        bookStore.addBook(new Book("1984", "George Orwell", 1949, new BigDecimal("8.99"), true));
+                // create books
+                bookStore.addBook(new PaperbackBook("The Great Gatsby", "F. Scott Fitzgerald", 1925,
+                                new BigDecimal("9.99")));
+                bookStore.addBook(new Ebook("To Kill a Mockingbird", "Harper Lee", 1960, new BigDecimal("7.99")));
+                bookStore.addBook(new AudioBook("1984", "George Orwell", 1949, new BigDecimal("8.99")));
 
-        // create users
-        bookStore.addUser(new User("Alice"));
-        bookStore.addUser(new User("Bob"));
+                // create users
+                bookStore.addUser(new User("Alice"));
+                bookStore.addUser(new User("Bob"));
 
-        // add books to cart
-        bookStore.getUsers().get(0).getCart().addItem(
-                new CartItem(bookStore.getBooks().get(0).getTitle(), bookStore.getBooks().get(0).getPrice(), 1));
-        bookStore.getUsers().get(0).getCart().addItem(
-                new CartItem(bookStore.getBooks().get(1).getTitle(), bookStore.getBooks().get(1).getPrice(), 2));
+                // add books to cart
+                bookStore.getUsers().get(0).getCart().addItem(
+                                new CartItem(bookStore.getBooks().get(0).getTitle(),
+                                                bookStore.getBooks().get(0).getPrice(), 1));
+                bookStore.getUsers().get(0).getCart().addItem(
+                                new CartItem(bookStore.getBooks().get(1).getTitle(),
+                                                bookStore.getBooks().get(1).getPrice(), 2));
 
-        // view cart
-        bookStore.getUsers().get(0).getCart().viewCartDetails();
+                // view cart
+                bookStore.getUsers().get(0).getCart().viewCartDetails();
 
-        // set shipping address and billing address
-        bookStore.getUsers().get(0)
-                .setShippingAddress(new Address("123 Main St", "", "Springfield", "IL", "62701", "USA"));
-        bookStore.getUsers().get(0)
-                .setBillingAddress(new Address("456 Elm St", "", "Springfield", "IL", "62702", "USA"));
+                // set shipping address and billing address
+                bookStore.getUsers().get(0)
+                                .setShippingAddress(
+                                                new Address("123 Main St", "", "Springfield", "IL", "62701", "USA"));
+                bookStore.getUsers().get(0)
+                                .setBillingAddress(new Address("456 Elm St", "", "Springfield", "IL", "62702", "USA"));
 
-        // checkout
-        bookStore.getUsers().get(0).checkout();
+                // checkout
+                bookStore.getUsers().get(0).checkout();
 
-        // view order details
-        bookStore.getUsers().get(0).viewOrders();
-    }
+                // view order details
+                bookStore.getUsers().get(0).viewOrders();
+        }
 }

--- a/src/Ebook.java
+++ b/src/Ebook.java
@@ -1,0 +1,8 @@
+import java.math.BigDecimal;
+
+public class Ebook extends Book {
+    public Ebook(String title, String author, int yearPublished, BigDecimal price) {
+        super(title, author, yearPublished, price);
+        this.bookType = "ebook";
+    }
+}

--- a/src/HardcoverBook.java
+++ b/src/HardcoverBook.java
@@ -1,0 +1,8 @@
+import java.math.BigDecimal;
+
+public class HardcoverBook extends Book {
+    public HardcoverBook(String title, String author, int yearPublished, BigDecimal price) {
+        super(title, author, yearPublished, price);
+        this.bookType = "hardcover";
+    }
+}

--- a/src/PaperbackBook.java
+++ b/src/PaperbackBook.java
@@ -1,0 +1,8 @@
+import java.math.BigDecimal;
+
+public class PaperbackBook extends Book {
+    public PaperbackBook(String title, String author, int yearPublished, BigDecimal price){
+        super(title, author, yearPublished, price);
+        this.bookType = "paperback";
+    }
+}


### PR DESCRIPTION
## Description
This PR adds adds support for other types of book aside paperback and non-paperback by creating child classes for each book type that inherit from the parent `Book` class.

## Issues
This PR closes issues #64 and #29.

## Changes Made
 - Created subclasses of the `Book` class for each type of book namely
      -  `PaperbackBook`
      -  `AudioBook`
      - `Ebook`
      - `HardcoverBook`
  - Replaced the `Book` class' `isPaperback` field with an immutable String `bookType` field indicating the type of book in question such as `"audiobook"` for the `AudioBook` class. etc.
  - Made the `Book` class abstract so it can't be instantiated directly.
  - Updated all calls of the `Book` constructor in `BookazonApp.java` with calls to specific `Book` subclass constructors.

## Why this Change?
This change adds support for new types of books in the Bookazon app which previously only supported Paperback vs. Non-paperback.
The previous implementation also violated the Open/Close SOLID software design principle and the new implementation with subclasses makes it easy to add support for more booktypes without having to modify unrelated code.