### PR TITLE
Use `java.time` types for date-related fields

### DIFF
--- a/src/bookazon/BookazonApp.java
+++ b/src/bookazon/BookazonApp.java
@@ -1,6 +1,7 @@
 package bookazon;
 
 import java.math.BigDecimal;
+import java.time.Year;
 
 import bookazon.books.AudioBook;
 import bookazon.books.Ebook;
@@ -14,10 +15,10 @@ public class BookazonApp {
                 BookStore bookStore = new BookStore();
 
                 // create books
-                bookStore.addBook(new PaperbackBook("The Great Gatsby", "F. Scott Fitzgerald", 1925,
+                bookStore.addBook(new PaperbackBook("The Great Gatsby", "F. Scott Fitzgerald", Year.of(1925),
                                 new BigDecimal("9.99")));
-                bookStore.addBook(new Ebook("To Kill a Mockingbird", "Harper Lee", 1960, new BigDecimal("7.99")));
-                bookStore.addBook(new AudioBook("1984", "George Orwell", 1949, new BigDecimal("8.99")));
+                bookStore.addBook(new Ebook("To Kill a Mockingbird", "Harper Lee", Year.of(1960), new BigDecimal("7.99")));
+                bookStore.addBook(new AudioBook("1984", "George Orwell", Year.of(1949), new BigDecimal("8.99")));
 
                 // create users
                 bookStore.addUser(new GoldUser("Alice"));

--- a/src/bookazon/Order.java
+++ b/src/bookazon/Order.java
@@ -3,12 +3,13 @@ package bookazon;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.time.LocalDate;
 
 import bookazon.users.User;
 
 public class Order {
-    private String dateCreated;
-    private String dateShipped;
+    private LocalDate dateCreated;
+    private LocalDate dateShipped;
     private String userName;
     private String orderStatus;
     private Address shippingAddress;
@@ -35,11 +36,11 @@ public class Order {
         this.orderStatus = status;
     }
 
-    public void setDateCreated(String date) {
+    public void setDateCreated(LocalDate date) {
         this.dateCreated = date;
     }
 
-    public void setDateShipped(String date) {
+    public void setDateShipped(LocalDate date) {
         this.dateShipped = date;
     }
 

--- a/src/bookazon/Order.java
+++ b/src/bookazon/Order.java
@@ -51,7 +51,7 @@ public class Order {
     public void printOrderDetails() {
         System.out.println("Order Details:");
         System.out.println("Date Created: " + dateCreated);
-        System.out.println("Date Shipped: " + dateShipped);
+        System.out.println("Date Shipped: " + (dateShipped != null ? dateShipped : "Order not shipped"));
         System.out.println("User Name: " + userName);
         System.out.println("Order Status: " + orderStatus);
         System.out.println("Shipping Address: " + (shippingAddress != null ? shippingAddress : "N/A"));

--- a/src/bookazon/books/AudioBook.java
+++ b/src/bookazon/books/AudioBook.java
@@ -1,9 +1,10 @@
 package bookazon.books;
 
 import java.math.BigDecimal;
+import java.time.Year;
 
 public class AudioBook extends Book {
-    public AudioBook(String title, String author, int yearPublished, BigDecimal price) {
+    public AudioBook(String title, String author, Year yearPublished, BigDecimal price) {
         super(title, author, yearPublished, price);
         this.bookType = "audio";
     }

--- a/src/bookazon/books/Book.java
+++ b/src/bookazon/books/Book.java
@@ -1,15 +1,16 @@
 package bookazon.books;
 
 import java.math.BigDecimal;
+import java.time.Year;
 
 public abstract class Book {
     private String title;
     private String author;
-    private int yearPublished;
+    private Year yearPublished;
     private BigDecimal price;
     protected String bookType;
 
-    public Book(String title, String author, int yearPublished, BigDecimal price) {
+    public Book(String title, String author, Year yearPublished, BigDecimal price) {
         setTitle(title);
         setAuthor(author);
         setYearPublished(yearPublished);
@@ -34,12 +35,11 @@ public abstract class Book {
         this.author = author;
     }
 
-    public int getYearPublished() {
+    public Year getYearPublished() {
         return yearPublished;
     }
 
-    public void setYearPublished(int yearPublished) {
-        validateYearPublished(yearPublished);
+    public void setYearPublished(Year yearPublished) {
         this.yearPublished = yearPublished;
     }
 
@@ -79,12 +79,6 @@ public abstract class Book {
     private void validateAuthor(String author) {
         if (author == null || author.isEmpty()) {
             throw new IllegalArgumentException("Invalid author.");
-        }
-    }
-
-    private void validateYearPublished(int yearPublished) {
-        if (yearPublished <= 0) {
-            throw new IllegalArgumentException("Invalid year published.");
         }
     }
 }

--- a/src/bookazon/books/Ebook.java
+++ b/src/bookazon/books/Ebook.java
@@ -1,9 +1,10 @@
 package bookazon.books;
 
 import java.math.BigDecimal;
+import java.time.Year;
 
 public class Ebook extends Book {
-    public Ebook(String title, String author, int yearPublished, BigDecimal price) {
+    public Ebook(String title, String author, Year yearPublished, BigDecimal price) {
         super(title, author, yearPublished, price);
         this.bookType = "ebook";
     }

--- a/src/bookazon/books/HardcoverBook.java
+++ b/src/bookazon/books/HardcoverBook.java
@@ -1,9 +1,10 @@
 package bookazon.books;
 
 import java.math.BigDecimal;
+import java.time.Year;
 
 public class HardcoverBook extends Book {
-    public HardcoverBook(String title, String author, int yearPublished, BigDecimal price) {
+    public HardcoverBook(String title, String author, Year yearPublished, BigDecimal price) {
         super(title, author, yearPublished, price);
         this.bookType = "hardcover";
     }

--- a/src/bookazon/books/PaperbackBook.java
+++ b/src/bookazon/books/PaperbackBook.java
@@ -1,9 +1,10 @@
 package bookazon.books;
 
 import java.math.BigDecimal;
+import java.time.Year;
 
 public class PaperbackBook extends Book {
-    public PaperbackBook(String title, String author, int yearPublished, BigDecimal price) {
+    public PaperbackBook(String title, String author, Year yearPublished, BigDecimal price) {
         super(title, author, yearPublished, price);
         this.bookType = "paperback";
     }

--- a/src/bookazon/users/User.java
+++ b/src/bookazon/users/User.java
@@ -1,6 +1,7 @@
 package bookazon.users;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 
 import bookazon.Address;
@@ -81,7 +82,7 @@ public abstract class User {
         order.setShippingAddress(new Address("123 Main St", "", "Springfield", "IL", "62701", "USA"));
         order.setBillingAddress(new Address("123 Main St", "", "Springfield", "IL", "62701", "USA"));
         order.setOrderStatus("Order Placed");
-        order.setDateCreated("2024-01-01");
+        order.setDateCreated(LocalDate.now());
         order.setUserName(this.name);
         orders.add(order);
         cart.clearCart();


### PR DESCRIPTION
## Description
This PR replaces the use of primitive `int` and `String` types to represent date-related information with appropriate dedicated datatypes in the `java.time` package.

## Issues
This PR closes issue #56.

## Changes Made
 - Update type of `Order` class' `dateShipped` and `dateCreated` fields with `java.time.LocalDate`
 - Update type of `Book` class' `yearPublished` field with `java.time.Year`
 - Remove validation for `yearPublished` field in `Book` class since the `java.time.Year` class already ensures that the year given complies with the proleptic ISO calendar system.

## Why this Change?
Using primitive types to represent date-related values is a primitive obsession code smell and needs to be updated for cleaner, less error-prone code..