### PR TITLE
Fix hardcoded billing and shipping address at checkout

### DIFF
--- a/src/bookazon/users/User.java
+++ b/src/bookazon/users/User.java
@@ -27,8 +27,8 @@ public abstract class User {
         this.name = otherUser.getName();
         this.cart = otherUser.getCart();
         this.orders = otherUser.getOrders();
-        this.shippingAddress = otherUser.getShippingAddress();
-        this.billingAddress = otherUser.getBillingAddress();
+        setShippingAddress(otherUser.getShippingAddress());
+        setBillingAddress(otherUser.getBillingAddress());
     }
 
     public void setName(String name) {
@@ -48,6 +48,7 @@ public abstract class User {
     }
 
     public void setShippingAddress(Address address) {
+        validateAddress(address);
         this.shippingAddress = address;
     }
 
@@ -56,6 +57,7 @@ public abstract class User {
     }
 
     public void setBillingAddress(Address address) {
+        validateAddress(address);
         this.billingAddress = address;
     }
 
@@ -79,12 +81,18 @@ public abstract class User {
 
     public void checkout() {
         Order order = new Order(cart, this);
-        order.setShippingAddress(new Address("123 Main St", "", "Springfield", "IL", "62701", "USA"));
-        order.setBillingAddress(new Address("123 Main St", "", "Springfield", "IL", "62701", "USA"));
+        order.setShippingAddress(this.shippingAddress);
+        order.setBillingAddress(this.billingAddress);
         order.setOrderStatus("Order Placed");
         order.setDateCreated(LocalDate.now());
         order.setUserName(this.name);
         orders.add(order);
         cart.clearCart();
+    }
+
+    private void validateAddress(Address address) {
+        if (address == null) {
+            throw new IllegalArgumentException("Invalid Address!");
+        }
     }
 }

--- a/src/bookazon/users/User.java
+++ b/src/bookazon/users/User.java
@@ -81,6 +81,8 @@ public abstract class User {
 
     public void checkout() {
         Order order = new Order(cart, this);
+        validateAddress(this.shippingAddress);
+        validateAddress(this.billingAddress);
         order.setShippingAddress(this.shippingAddress);
         order.setBillingAddress(this.billingAddress);
         order.setOrderStatus("Order Placed");


### PR DESCRIPTION
## Description
This PR resolves an issue with the `User` class' `checkout()` method which uses a hardcoded shipping and billing address to create orders regardless of the current user's shipping or billing address.
The current user's shipping and billing address is used instead and a validation check is done to ensure the current user has a set shipping and billing address during checkout.

## Issues
This PR closes issue #57 .

## Changes Made
 - Replace hardcoded order shipping and billing address in `checkout()` with current user's shipping and billing address.
 - Add `validateAddress()` method for validating addresses.
 - Validate current user's shipping and billing address during checkout.

## Why this Change?
It is critical for the Bookazon App to support shipping to the user's specified address rather than a hardcoded one.